### PR TITLE
Minor fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Support of Shape Expression Language 2.0 (http://shex.io/shex-semantics/index.html) and validation.
 
 The validation algorithms implemented are the one that appears in:
-```json
+```bibtex
 @inproceedings{boneva:hal-01590350,
   TITLE = {{Semantics and Validation of Shapes Schemas for RDF}},
   AUTHOR = {Boneva, Iovka and Labra Gayo, Jose G and Prud 'hommeaux, Eric G},


### PR DESCRIPTION
I changed to ```bibtex because the syntax coloring done by github when using ```css does not look very nice.